### PR TITLE
Enforce image safety during image_conversion

### DIFF
--- a/glance/common/config.py
+++ b/glance/common/config.py
@@ -100,6 +100,18 @@ image_format_opts = [
                        "image attribute"),
                 deprecated_opts=[cfg.DeprecatedOpt('disk_formats',
                                                    group='DEFAULT')]),
+    cfg.ListOpt('vmdk_allowed_types',
+                default=['streamOptimized', 'monolithicSparse'],
+                help=_("A list of strings describing allowed VMDK "
+                       "'create-type' subformats that will be allowed. "
+                       "This is recommended to only include "
+                       "single-file-with-sparse-header variants to avoid "
+                       "potential host file exposure due to processing named "
+                       "extents. If this list is empty, then no VDMK image "
+                       "types allowed. Note that this is currently only "
+                       "checked during image conversion (if enabled), and "
+                       "limits the types of VMDK images we will convert "
+                       "from.")),
 ]
 task_opts = [
     cfg.IntOpt('task_time_to_live',


### PR DESCRIPTION
This does two things:

1. It makes us check that the QCOW backing_file is unset on those
types of images. Nova and Cinder do this already to prevent an
arbitrary (and trivial to accomplish) host file exposure exploit.
2. It makes us restrict VMDK files to only allowed subtypes. These
files can name arbitrary files on disk as extents, providing the
same sort of attack. Default that list to just the types we believe
are actually useful for openstack, and which are monolithic.

The configuration option to specify allowed subtypes is added in
glance's config and not in the import options so that we can extend
this check later to image ingest. The format_inspector can tell us
what the type and subtype is, and we could reject those images early
and even in the case where image_conversion is not enabled.

Closes-Bug: #1996188
Change-Id: Idf561f6306cebf756c787d8eefdc452ce44bd5e0
(cherry picked from commit 0d6282a01691cecc2798f7858b181c4bb30f850c)
(cherry picked from commit 4967ab6935cfd0274ae801ac943d01909a236a0a)
(cherry picked from commit dc8e5a5cc7f5e9d1b697e520a7533cc90516db1b)
