### PR TITLE
Fix performance glitch while sorting image locations

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -24,10 +24,10 @@ postgresql-server [platform:rpm]
 postgresql-server-devel [platform:suse]  # Provides pg_config
 libpython3-dev [platform:dpkg]
 python3-devel [platform:rpm]
-qemu [platform:dpkg devstack build-image-dib]
-qemu-utils [platform:dpkg devstack build-image-dib]
-qemu-img [platform:redhat]
-qemu-tools [platform:suse]  # Provides qemu-img
+qemu [platform:dpkg devstack build-image-dib test]
+qemu-utils [platform:dpkg devstack build-image-dib test]
+qemu-img [platform:redhat test]
+qemu-tools [platform:suse test]  # Provides qemu-img
 libpq-dev [platform:dpkg]
 libpcre3-dev [platform:dpkg]
 pcre-devel [platform:redhat]

--- a/glance/common/utils.py
+++ b/glance/common/utils.py
@@ -724,13 +724,12 @@ def sort_image_locations(locations):
         if not store_id:
             return 0
         try:
-            store = glance_store.get_store_from_store_identifier(store_id)
+            return glance_store.get_store_weight(store_id)
         except glance_store.exceptions.UnknownScheme:
             msg = (_LW("Unable to find store '%s', returning "
                        "default weight '0'") % store_id)
             LOG.warning(msg)
             return 0
-        return store.weight if store is not None else 0
 
     sorted_locations = sorted(locations, key=get_store_weight, reverse=True)
     LOG.debug(('Sorted locations: %s'), sorted_locations)

--- a/glance/tests/unit/common/test_utils.py
+++ b/glance/tests/unit/common/test_utils.py
@@ -189,7 +189,7 @@ class TestUtils(test_utils.BaseTestCase):
             'url': 'rbd://cccccccc/images/id',
             'metadata': {'store': 'rbd3'}
         }]
-        mp = "glance.common.utils.glance_store.get_store_from_store_identifier"
+        mp = "glance.common.utils.glance_store.get_store_weight"
         with mock.patch(mp) as mock_get_store:
             utils.sort_image_locations(locations)
 
@@ -215,10 +215,9 @@ class TestUtils(test_utils.BaseTestCase):
             'url': 'rbd://cccccccc/images/id',
             'metadata': {'store': 'rbd3'}
         }]
-        mp = "glance.common.utils.glance_store.get_store_from_store_identifier"
+        mp = "glance.common.utils.glance_store.get_store_weight"
         with mock.patch(mp) as mock_get_store:
-            mock_store = mock_get_store.return_value
-            mock_store.weight = 100
+            mock_get_store.return_value = 100
             utils.sort_image_locations(locations)
 
         # Since 3 stores are configured, internal method will be called 3 times
@@ -243,7 +242,7 @@ class TestUtils(test_utils.BaseTestCase):
             'url': 'rbd://cccccccc/images/id',
             'metadata': {}
         }]
-        mp = "glance.common.utils.glance_store.get_store_from_store_identifier"
+        mp = "glance.common.utils.glance_store.get_store_weight"
         with mock.patch(mp) as mock_get_store:
             utils.sort_image_locations(locations)
 
@@ -270,10 +269,9 @@ class TestUtils(test_utils.BaseTestCase):
             'url': 'rbd://cccccccc/images/id',
             'metadata': {}
         }]
-        mp = "glance.common.utils.glance_store.get_store_from_store_identifier"
+        mp = "glance.common.utils.glance_store.get_store_weight"
         with mock.patch(mp) as mock_get_store:
-            mock_store = mock_get_store.return_value
-            mock_store.weight = 100
+            mock_get_store.return_value = 100
             utils.sort_image_locations(locations)
 
         # Since 3 stores are configured, but only one location has
@@ -300,7 +298,7 @@ class TestUtils(test_utils.BaseTestCase):
             'url': 'rbd://cccccccc/images/id',
             'metadata': {'store': 'rbd3'}
         }]
-        mp = "glance.common.utils.glance_store.get_store_from_store_identifier"
+        mp = "glance.common.utils.glance_store.get_store_weight"
         with mock.patch(mp) as mock_get_store:
             mock_get_store.side_effect = store.UnknownScheme()
             sorted_locations = utils.sort_image_locations(locations)

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ retrying!=1.3.0,>=1.2.3 # Apache-2.0
 osprofiler>=1.4.0 # Apache-2.0
 
 # Glance Store
-glance-store>=2.3.0 # Apache-2.0
+glance-store @ git+https://github.com/stackhpc/glance_store@stackhpc/4.7.0.3 # Apache-2.0
 
 
 debtcollector>=1.19.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ setenv =
   OS_TEST_DBAPI_ADMIN_CONNECTION=sqlite:////tmp/placeholder-never-created-nor-used.db
 # TODO(stephenfin): Remove once we bump our upper-constraint to SQLAlchemy 2.0
   SQLALCHEMY_WARN_20=1
+  TOX_CONSTRAINTS_FILE=https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/2024.1/upper-constraints.txt
 usedevelop = True
 install_command = python -m pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1} {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Some of the available glance stores like file, cinder etc has capability to reuse already initiated driver (DRIVER_REUSABLE = 0b01000000). In Caracal we have added a feature to sort image locations based on store weight. As RBD driver of glance does not have this reuse capability, during image list API call it initializes the RBD driver for each of the available image which is causing noticable delay in list call.

To avoid this, using new interface added in glance_store which will directly get the weight of the store from memory and return it back to user.

Depends-On: https://github.com/stackhpc/glance_store/pull/3 
Closes-Bug: #2086675
Change-Id: I662ba19697e03917ca999920ea7be93a0b2a8296 (cherry picked from commit ce537e073b2e7efb332d719bb45bf20c403c140a)