### PR TITLE
Bump glance-store requirement to 4.7.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ retrying!=1.3.0,>=1.2.3 # Apache-2.0
 osprofiler>=1.4.0 # Apache-2.0
 
 # Glance Store
-glance-store @ git+https://github.com/stackhpc/glance_store@stackhpc/4.7.0.6 # Apache-2.0
+glance-store @ git+https://github.com/stackhpc/glance_store@stackhpc/4.7.1.1 # Apache-2.0
 
 
 debtcollector>=1.19.0 # Apache-2.0


### PR DESCRIPTION
No functional change: the version number should already have been higher than 4.7.1 but it was not bumped because of missing tags in our fork.

Change-Id: I06e1286f77e421c2fe1bf0beeb685e3fa383e1ad